### PR TITLE
switch to puma on heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem 'binding_of_caller'
 
 gem 'tux'
 gem 'faker'
+
+gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
     json (1.8.3)
     minitest (5.8.0)
     pg (0.18.3)
+    puma (2.15.3)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -72,6 +73,7 @@ DEPENDENCIES
   binding_of_caller
   faker
   pg
+  puma
   sinatra
   sinatra-activerecord
   sqlite3

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -p $PORT -C ./config/puma.rb

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,9 @@
+workers 1
+threads_count = Integer(ENV['MAX_THREADS'] || 8)
+threads threads_count, threads_count
+ 
+preload_app!
+ 
+on_worker_boot do
+  ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Sets server type to Puma on Heroku.

Configure concurrency settings in /config/puma.rb
or in terminal
example:
heroku config:set MAX_THREADS/MIN_THREADS/WORKERS=[number]